### PR TITLE
Fixed README example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and ensures a clone is performed recursively.
 To use this data object base class for your own data objects, just use
 something like this:
 
-    class Person extends \Kore\DataObject\DataObject
+    class Person extends \Kore\DataObject\Struct
     {
         public $prename;
 


### PR DESCRIPTION
I guess the correct class name is `\Kore\DataObject\Struct`?
