### PR TITLE
Fixed: Clone data objects that implement iterators

### DIFF
--- a/src/Kore/DataObject/DataObject.php
+++ b/src/Kore/DataObject/DataObject.php
@@ -58,7 +58,7 @@ class DataObject
      */
     public function __clone()
     {
-        foreach ($this as $property => $value) {
+        foreach (get_object_vars($this) as $property => $value) {
             if (is_object($value)) {
                 $this->$property = clone $value;
             }


### PR DESCRIPTION
If a data object implements Iterator or IteratorAggregate, the clone fails here. Using `get_object_vars()` fixes this behavior.